### PR TITLE
Use `link` liquid tag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 TODO write docs for staff here
 
+## Liquid Tags
+
+[Liquid](https://shopify.github.io/liquid/) is a template language. Liquid tags look like `{% tag_name ... %}` and you can read more about how they work with Jekyll [here](https://jekyllrb.com/docs/liquid/).
+
+Some tags you may find useful:
+
+- [`{% link <path> %}`](https://jekyllrb.com/docs/liquid/tags/#links)
+
 ## Continuous Integration (GitHub Actions)
 
 TODO Info here about workflows and links

--- a/_modules/week-01.md
+++ b/_modules/week-01.md
@@ -15,9 +15,9 @@ Sep 30
   : [1.2](#), [2.1](#)
 
 Oct 1
-: **Lab**{: .label .label-purple } [Lab 1: Control and Functions]({{ site.baseurl }}/labs/lab01)
+: **Lab**{: .label .label-purple } [Lab 1: Control and Functions]({% link _labs/lab01.md %})
 
 Oct 2
 : [Tracing, IntLists, & Recursion](#)
   : [2.1](#)
-: **HW 1 due**{: .label .label-red } [HW 1: Recursion]({{ site.baseurl }}/hw/hw01)
+: **HW 1 due**{: .label .label-red } [HW 1: Recursion]({% link _hw/hw01.md %})

--- a/_modules/week-02.md
+++ b/_modules/week-02.md
@@ -15,7 +15,7 @@ Oct 7
   : [2.4](#), [2.5](#)
 
 Oct 8
-: **Project**{: .label .label-green } [Project 1: Ants vs. Some Bees]({{ site.baseurl }}/projects/proj01)
+: **Project**{: .label .label-green } [Project 1: Ants vs. Some Bees]({% link _projects/proj01.md %})
 
 Oct 9
 : [Runtime Analysis](#)


### PR DESCRIPTION
Use liquid `link` tags instead of using the site baseurl variable every time.