### PR TITLE
Accessible Default Static Calendar Event Color

### DIFF
--- a/_calendars/weekly.md
+++ b/_calendars/weekly.md
@@ -49,6 +49,11 @@ schedule:
         end: 2:00 PM
         location: 271 Soda
   - name: Thursday
+    events:
+      - name: Drop In's
+        start: 1:00 PM
+        end: 3:00 PM
+        location: 271 Soda
   - name: Friday
     events:
       - name: Lecture

--- a/_sass/just-the-class/schedule.scss
+++ b/_sass/just-the-class/schedule.scss
@@ -72,7 +72,7 @@
   }
 
   .schedule-event {
-    background-color: $grey-dk-000;
+    background-color: $berkeley-blue;
     border-radius: $border-radius;
     box-shadow: 0 10px 20px rgba(0, 0, 0, .1), inset 0 -3px 0 rgba(0, 0, 0, .2);
     color: $white;


### PR DESCRIPTION
Closes #83 

Change the default background color for an event to the Berkeley Blue which will meet color contrast standards in both dark and light mode