### PR TITLE
Theme Toggle Works with JTD 0.11

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,8 +21,6 @@ tagline: A Jekyll template for course websites
 description: A modern, highly customizable, responsive Jekyll template for course websites
 # TODO(template): this should be built from the staff list...
 author: Various Bears
-# You should use either light or dark as the theme.
-color_scheme: light
 
 # TODO(setup): Set this to the semester, e.g. /sp24, (faXX / spXX / suXX / wiXX )
 baseurl: '/berkeley-class-site' # the subpath of your site, which should just be the semester.

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,4 +1,9 @@
   <!-- Use this to add global CSS/JS utitlties. -->
+<script>
+  // Quick-set theme to prevent flashing
+  const theme = localStorage.getItem('jtd-theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', theme);
+</script>
 
   <!-- Loading the v6 core styles and the Solid and Brands styles -->
   <link href="{{ site.baseurl }}/assets/vendor/fontawesome/css/fontawesome.css" rel="stylesheet" />

--- a/_includes/toggle-color-scheme.html
+++ b/_includes/toggle-color-scheme.html
@@ -20,61 +20,74 @@
   <button type="button"
     class="btn js-unset-color-scheme btn-outline px-2"
     style="margin-left: -3px; border-top-left-radius: 0; border-bottom-left-radius: 0;"
-    aria-label="Automatically switch theme"
-    ><i class="fa-solid fa-rotate" title="Automatically switch theme"></i></button>
+    aria-label="Use system appearance"
+    ><i class="fa-solid fa-rotate" title="Use system appearance"></i></button>
 </span>
 
 <script>
+(function() {
+  // Prevent double-loading
+  if (window.themeScriptRan) return;
+  window.themeScriptRan = true;
+
   document.addEventListener("DOMContentLoaded", function() {
-    if (!jtd) { return; }
+    // Check if JTD is actually loaded
+    if (typeof jtd === 'undefined') {
+      console.error("JTD is not defined. Check if jtd.js is loading.");
+      return; 
+    }
 
     const toggleSchemeBtn = document.querySelector('.js-toggle-dark-mode');
     const unsetColorScheme = document.querySelector('.js-unset-color-scheme');
 
-    // If the browser suggests a color scheme, and user hasn't saved/switch one yet..
-    if (window.matchMedia && !localStorage['jtd-theme']) {
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        jtd.setTheme('dark');
+    function updateButtonUI(theme) {
+      if (!toggleSchemeBtn) return;
+      if (theme === 'dark') {
         toggleSchemeBtn.textContent = '🔆 Light Mode';
         toggleSchemeBtn.ariaLabel = 'Switch to Light Mode';
-      } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-        jtd.setTheme('light');
+      } else {
         toggleSchemeBtn.textContent = '🌙 Dark Mode';
         toggleSchemeBtn.ariaLabel = 'Switch to Dark Mode';
       }
-    } else if (localStorage['jtd-theme']) {
-      jtd.setTheme(localStorage['jtd-theme']);
     }
 
+    // Apply theme before button listeners
+    const savedTheme = localStorage.getItem('jtd-theme');
+    const systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const initialTheme = savedTheme || (systemDark ? 'dark' : 'light');
+
+    jtd.setTheme(initialTheme);
+    updateButtonUI(initialTheme);
+
+    // Toggle Logic
     jtd.addEvent(toggleSchemeBtn, 'click', function() {
-      if (jtd.getTheme() === 'dark') {
-        localStorage['jtd-theme'] = 'light';
-        jtd.setTheme('light');
-        toggleSchemeBtn.textContent = '🌙 Dark Mode';
-        toggleSchemeBtn.ariaLabel = 'Switch to Dark Mode';
-      } else {
-        jtd.setTheme('dark');
-        localStorage['jtd-theme'] = 'dark';
-        toggleSchemeBtn.textContent = '🔆 Light Mode';
-        toggleSchemeBtn.ariaLabel = 'Switch to Light Mode';
-      }
+      const current = document.documentElement.getAttribute('data-theme') || jtd.getTheme();
+      const nextTheme = (current === 'dark') ? 'light' : 'dark';
+
+      console.log("Toggling from", current, "to", nextTheme);
+
+      jtd.setTheme(nextTheme);
+      localStorage.setItem('jtd-theme', nextTheme);
+      updateButtonUI(nextTheme);
     });
 
-    // Add a way to unset the saved theme.
-    // "default" respect's the site config setting, but not the user browser pref
-    // So, check the pref and set the theme to the preferred one, if possible.
-    jtd.addEvent(unsetColorScheme, 'click', function() {
-      delete localStorage['jtd-theme'];
+    // Reset Logic (Sync with system preference)
+    if (unsetColorScheme) {
+      jtd.addEvent(unsetColorScheme, 'click', function() {
+        // Clear the manual override
+        localStorage.removeItem('jtd-theme');
 
-      if (window.matchMedia) {
-        if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-          jtd.setTheme('dark');
-        } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-          jtd.setTheme('light');
-        }
-      } else {
-        jtd.setTheme('default');
-      }
-    });
+        // Determine what the system wants
+        const systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const newTheme = systemDark ? 'dark' : 'light';
+
+        // Apply it immediately without reloading
+        jtd.setTheme(newTheme);
+        updateButtonUI(newTheme);
+        
+        console.log("Reset to system preference:", newTheme);
+      });
+    }
   });
+})();
 </script>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -7,7 +7,6 @@
 // Just the Class customizations are all loaded in one file.
 @import '../just-the-class/just-the-class';
 @import '../berkeley/berkeley';
-
 @import '../color_schemes/dark_overrides';
 
 div.highlighter-rouge {


### PR DESCRIPTION
#86 introduced a bug with the theme toggling where it stopped working while in dark mode because of the upgrade to JTD gem. This PR fixes that issue. It also closes #60 because it clarifies the favicon which is really a "reset" to system preferences button--not a toggle between light/dark mode.