### PR TITLE
Use relative_url instead of site.baseurl

### DIFF
--- a/_discussions/disc01.md
+++ b/_discussions/disc01.md
@@ -4,9 +4,9 @@ description: By the numbers
 due: "2024-06-13 11:59:59 PM PST"
 gradescope_assignment_id: 3858565
 submission_files:
-    - disc01.pdf
+    - dis01.pdf
 pdfs:
-    - disc01.pdf
+    - dis01.pdf
 links:
     - name: Discussion 1 Handout
       url: https://drive.google.com/file/d/1rl5TLpZde5dx15b806IXHqU4NIgZxWli/view

--- a/_includes/fullcalendar-assets.html
+++ b/_includes/fullcalendar-assets.html
@@ -10,15 +10,9 @@
 
 <!-- This is the whole bundle...maybe we can load smaller components...? -->
 <script type="text/javascript"
-  src="{{ site.baseurl }}/assets/vendor/fullcalendar/dist/index.global.min.js"></script>
-<!-- <script type="text/javascript"
-  src="{{ site.baseurl }}/assets/vendor/fullcalendar/packages/core/index.global.min.js"></script>
+  src="{{ 'assets/vendor/fullcalendar/dist/index.global.min.js' | relative_url }}"></script>
 <script type="text/javascript"
-  src="{{ site.baseurl }}/assets/vendor/fullcalendar/packages/daygrid/index.global.min.js"></script>
-<script type="text/javascript"
-  src="{{ site.baseurl }}/assets/vendor/fullcalendar/packages/timegrid/index.global.min.js"></script> -->
-<script type="text/javascript"
-  src="{{ site.baseurl }}/assets/vendor/fullcalendar/packages/google-calendar/index.global.min.js"></script>
+  src="{{ 'assets/vendor/fullcalendar/packages/google-calendar/index.global.min.js' | relative_url }}"></script>
 
 <style type="text/css">
   main {

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -6,6 +6,6 @@
 </script>
 
   <!-- Loading the v6 core styles and the Solid and Brands styles -->
-  <link href="{{ site.baseurl }}/assets/vendor/fontawesome/css/fontawesome.css" rel="stylesheet" />
-  <link href="{{ site.baseurl }}/assets/vendor/fontawesome/css/solid.css" rel="stylesheet" />
-  <!-- <link href="{{ site.baseurl }}/assets/vendor/fontawesome/css/brands.css" rel="stylesheet" /> -->
+  <link href="{{ 'assets/vendor/fontawesome/css/fontawesome.css' | relative_url }}" rel="stylesheet" />
+  <link href="{{ 'assets/vendor/fontawesome/css/solid.css' | relative_url }}" rel="stylesheet" />
+  <!-- <link href="{{ 'assets/vendor/fontawesome/css/brands.css' | relative_url }}" rel="stylesheet" /> -->

--- a/_layouts/calendar_dynamic.html
+++ b/_layouts/calendar_dynamic.html
@@ -8,4 +8,4 @@ layout: default
 
 <div id="full-calendar"></div>
 
-<script type="text/javascript" src="{{ site.baseurl }}/assets/scripts/fullcalendar.js"></script>
+<script type="text/javascript" src="{{ 'assets/scripts/fullcalendar.js' | relative_url }}"></script>

--- a/_layouts/discussion.html
+++ b/_layouts/discussion.html
@@ -10,8 +10,7 @@ layout: default
         {%- if page.pdfs -%}
             <h2>Materials</h2>
             {%- for pdf in page.pdfs -%}
-                <a href="{{ site.baseurl }}/{{ page.subpath }}{{ pdf }}" class="btn btn-outline-primary" style="margin-right: 10px;" target="_blank">
-                    View {{ pdf }}
+                <a href="{{ page.subpath | append: pdf | relative_url }}" class="btn btn-outline-primary" style="margin-right: 10px;" target="_blank">                    View {{ pdf }}
                 </a>
             {%- endfor -%}
         {%- endif -%}

--- a/_layouts/staffer.html
+++ b/_layouts/staffer.html
@@ -1,9 +1,9 @@
 <div class="staffer">
-  {%- if page.photo -%}
-  <img class="staffer-image" src="{{ site.baseurl }}{{ page.subpath }}{{ page.photo }}" alt="{{ page.name }} profile photo" width="{{ page.width }}" height="{{ page.height }}">
-  {%- else -%}
-  <img class="staffer-image" src="{{ site.baseurl }}{{ page.subpath }}default_photo.jpg" alt="{{ page.name }} profile photo" width="{{ page.width }}" height="{{ page.height }}">
-  {%- endif -%}
+{%- if page.photo -%}
+<img class="staffer-image" src="{{ page.subpath | append: page.photo | relative_url }}" alt="{{ page.name }} profile photo" width="{{ page.width }}" height="{{ page.height }}">
+{%- else -%}
+<img class="staffer-image" src="{{ page.subpath | append: 'default_photo.jpg' | relative_url }}" alt="{{ page.name }} profile photo" width="{{ page.width }}" height="{{ page.height }}">
+{%- endif -%}
   <div>
     <h3 class="staffer-name" id="{{ page.name | slugify }}">
       {%- if page.website -%}

--- a/calendar_dynamic.md
+++ b/calendar_dynamic.md
@@ -9,9 +9,6 @@ nav_order: 3
 Use this calendar if you want to integrate your class's Google Calendar into the website. 
 
 ## Directions
-{: .important }
-If your `baseurl` is set to `/`, your calendar will not display out of the box. You need to edit `_includes/fullcalendar-assets.html` and `_layouts/calendar_dynamic.html` as in [this commit](https://github.com/prob140/prob140.github.io/commit/c4a926e8076af03b761009066248ed88ed126062) to remove the `/` before `assets` to avoid it resolving to `//assets`.
-
 1. Ensure there is a calendar for your course. You may reuse the previous semester's calendar if it exists. We suggest that calendars belong to a course's SPA. [Directions for creating a new calendar here.](https://support.google.com/calendar/answer/37095?hl=en)
 1. In `config.yml`, set `google_calendar_id` to the calendar's Calendar ID from the [settings page](https://support.google.com/calendar/answer/6084644?hl=en&co=GENIE.Platform%3DDesktop). 
 1. Create a Google API Key. You may be able to reuse the previous semester's API key if one exists.

--- a/docs/editing-content.md
+++ b/docs/editing-content.md
@@ -9,6 +9,11 @@ nav_order: 1
 
 # Editing Content
 
+{% raw %}
+{: .important}
+If you're adding references to files, please use `{{ 'path/to/file' | relative_url }}` instead of `{{ site.baseurl }}/path/to/file`. In most cases using the baseurl is fine, but some classes have found this problematic. 
+{% endraw %}
+
 ## Jekyll
 
 [Jekyll][jekyll] is the static site generator we use to build the website. We highly recommend reading through the documentation to get an idea of what you can achieve with Jekyll, such as variables, collections, and page layouts, if you wish to customize your website further. However, if you are okay with the boilerplate collections we provide in this template, it is not strictly necessary.

--- a/robots.txt
+++ b/robots.txt
@@ -4,4 +4,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: {{site.url}}{{ site.baseurl }}/sitemap.xml
+Sitemap: {{ '/sitemap.xml' | absolute_url }}


### PR DESCRIPTION
Data 140 and Data 145 do not have an archive page and serve their websites directly at their domain instead of domain/semXX. This causes problems for things like `{{ site.baseurl }}/assets/...` but using a relative (or absolute) reference works without issue. I have changed the template to only use relative references.

Incidentally I also corrected some mistyped file names for the discussion example within the discussion collection.