### PR TITLE
Optional Week Labels

### DIFF
--- a/_data/weeks.yml
+++ b/_data/weeks.yml
@@ -1,0 +1,14 @@
+### WEEK LABELS ###
+# entries should either be 
+# title: "title here" 
+# or
+# skip: true
+# if you provide fewer titles than weeks on your calendar, 
+# the weeks without titles will not be labeled 
+# you can also delete this file if you don't want to have any labeled weeks
+weeks:
+  - title: "Introduction"
+  - skip: true
+  - title: "Pandas and API"
+  - title: "Surveys and RCTs"
+  - title: "Visualization"

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -69,7 +69,16 @@
     {%- assign week_number = forloop.index0 -%}
   {%- endif -%}
 
-  <h2 id="week-{{ week.name }}" class="week-label">Week {{ week_number }}</h2>
+  {%- comment -%} Look up the week info from _data/weeks.yml using the current loop index {%- endcomment -%}
+  {%- assign week_index = forloop.index0 -%}
+  {%- assign week_info = site.data.weeks.weeks[week_index] -%}
+
+  <h2 id="week-{{ week_number }}" class="week-label">
+    Week {{ week_number }}
+    {%- if week_info.title and week_info.skip != true -%}
+      : {{ week_info.title }}
+    {%- endif -%}
+  </h2>
   
   <table class="spanned-table" style="margin-bottom: 1.5rem; table-layout: fixed; width: 100%;">
     <tbody>


### PR DESCRIPTION
Econ 148 wanted to be able to add labels for the weeks. This PR 

- [X] creates `_data/weeks.yml` where week labels can be set
- [X] updates `_includes/schedule.html` to take the week labels into account if provided
- [X] fixes the week anchoring as described in #102 (announcement anchoring is still not correct)

Week labels are not necessary. `_data/weeks.yml` can even be deleted without causing problems. 

Here's what this looks like on the schedule (week 2 intentionally skipped)
<img width="530" height="725" alt="Screenshot 2026-01-21 at 10 22 20 PM" src="https://github.com/user-attachments/assets/b3a028ab-892b-4532-a1e1-f88ca13878a9" />
