### PR TITLE
Add quizzes to schedule

### DIFF
--- a/_data/quizzes.yml
+++ b/_data/quizzes.yml
@@ -1,0 +1,23 @@
+### QUIZ ORDERING ###
+# each entry requires either a 'slug' or a 'title' field
+
+# use the slug if you utilize the _quizzes collection. this will take info
+# from the front matter of the corresponding file in _quizzes/
+# if your filename has a leading zero, quotes are required around the slug
+# if you use the _quizzes collection, the title field will be useful for
+# one-off overrides like holidays or for placeholders; use the title field sparingly
+
+# nonumber supresses the label and numbering for the quiz entry
+# skip: true will omit the quiz from the schedule entirely
+
+# link overrides the default link to the quiz page from the collection if 
+# you provided a slug or provides an external link
+quizzes:
+  - title : "Academic and Administrative Holiday"
+    nonumber: true
+  - title: "Quiz 1 Scope" # 1
+    link: https://edstem.org/
+  - title: "" # 2
+  - title: "" # 3
+  - skip: true
+  - skip: true

--- a/_data/syllabus.yml
+++ b/_data/syllabus.yml
@@ -4,7 +4,7 @@
 
 # Set start_date to the Monday of the first week of instruction.
 # Set end_date to the Friday of exams week.
-start_date: 2026-01-20
+start_date: 2026-01-19
 end_date: 2026-02-21
 
 # Any other days you want to appear on the calendar (e.g. for one-time events
@@ -33,6 +33,7 @@ discussion_days: ['2']
 lab_days: ['2']
 hw_days: ['5']
 hw_due_days: ['4']
+quiz_days: ['1']
 
 # Where should we start automatically numbering each course component?
 # For example, if you set starting_homework_number to 0, then the first homework
@@ -44,6 +45,7 @@ starting_discussion_number: '0'
 starting_homework_number: '1'
 starting_lab_number: '1'
 starting_project_number: '1'
+starting_quiz_number: '1'
 # Is the first week of class Week 0 or Week 1? We currently don't support
 # starting at any other week number, so pick '0' or '1' here.
 starting_week_number: '1'

--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -29,7 +29,8 @@
     site.data.syllabus.discussion_days contains day_of_week or 
     site.data.syllabus.lab_days contains day_of_week or 
     site.data.syllabus.hw_days contains day_of_week or
-    site.data.syllabus.hw_due_days contains day_of_week -%}
+    site.data.syllabus.hw_due_days contains day_of_week or
+    site.data.syllabus.quiz_days contains day_of_week -%}
     {%- assign valid_dates = valid_dates | push: date -%}
   {%- endif -%}
 {%- endfor -%}
@@ -58,11 +59,13 @@
 {%- assign lab_index = 0 -%}
 {%- assign homework_index = 0 -%}
 {%- assign homework_due_index = 0 -%}
+{%- assign quiz_index = 0 -%}
 {%- assign lecture_number = site.data.syllabus.starting_lecture_number | default: 1 -%}
 {%- assign discussion_number = site.data.syllabus.starting_discussion_number | default: 1 -%}
 {%- assign lab_number = site.data.syllabus.starting_lab_number | default: 1 -%}
 {%- assign homework_number = site.data.syllabus.starting_homework_number | default: 1 -%}
 {%- assign homework_due_number = site.data.syllabus.starting_homework_number | default: 1 -%}
+{%- assign quiz_number = site.data.syllabus.starting_quiz_number | default: 1 -%}
 
 <div class="syllabus-container">
 {%- for week in sorted_dates -%}
@@ -168,6 +171,57 @@
 
                     {%- comment -%} 5. ALWAYS INCREMENT INDEX TO MOVE TO NEXT YAML ENTRY {%- endcomment -%}
                     {%- assign lecture_index = lecture_index | plus: 1 -%}
+                {%- endif -%}
+            {%- endif -%}
+
+            {%- comment -%} --- QUIZ LOGIC --- {%- endcomment -%}
+            {%- if site.data.syllabus.quiz_days contains day_of_week -%}
+                {%- assign quiz_entry = site.data.quizzes.quizzes[quiz_index] -%}
+                
+                {%- if quiz_entry -%}
+                    {%- unless quiz_entry.skip -%}
+                        <div class="syllabus-item" style="margin-bottom: 4px;">
+                            {%- assign quiz_obj = nil -%}
+                            
+                            {%- comment -%} 1. FIND THE OBJECT (If slug exists) {%- endcomment -%}
+                            {%- if quiz_entry.slug -%}
+                                {%- assign target_slug = quiz_entry.slug | append: "" -%}
+                                {%- for q in site.quizzes -%}
+                                    {%- if q.slug == target_slug -%}
+                                        {%- assign quiz_obj = q -%}
+                                        {%- break -%}
+                                    {%- endif -%}
+                                {%- endfor -%}
+                            {%- endif -%}
+
+                            {%- comment -%} 2. DETERMINE TITLE AND LINK {%- endcomment -%}
+                            {%- assign display_title = quiz_entry.title | default: quiz_obj.title -%}
+                            
+                            {%- if quiz_entry.link -%}
+                                {%- assign display_link = quiz_entry.link -%}
+                            {%- elsif quiz_obj -%}
+                                {%- assign display_link = quiz_obj.url | relative_url -%}
+                            {%- else -%}
+                                {%- assign display_link = nil -%}
+                            {%- endif -%}
+
+                            {%- comment -%} 3. RENDER LABEL (Unless nonumber is true) {%- endcomment -%}
+                            {%- unless quiz_entry.nonumber -%}
+                                <strong class="label label-quiz">QUIZ {{ quiz_number }}</strong>
+                                {%- assign quiz_number = quiz_number | plus: 1 -%}
+                            {%- endunless -%}
+
+                            {%- comment -%} 4. RENDER LINK OR TITLE {%- endcomment -%}
+                            {%- if display_link -%}
+                                <a href="{{ display_link }}">{{ display_title }}</a>
+                            {%- else -%}
+                                <span>{{ display_title }}</span>
+                            {%- endif -%}
+                        </div>
+                    {%- endunless -%}
+
+                    {%- comment -%} 5. ALWAYS INCREMENT INDEX {%- endcomment -%}
+                    {%- assign quiz_index = quiz_index | plus: 1 -%}
                 {%- endif -%}
             {%- endif -%}
 


### PR DESCRIPTION
I was originally going to add both quizzes and exams as their own `_data/file.yml` in this PR, but at this point in time I feel better about adding only quizzes. Typically classes have up to three midterms and a final exam, so this is up to 4 entries in `extra_days_col2` (found in `_data/syllabus.yml`). With `_data/exams.yml`, I'd just be reproducing the same logic as projects and extra_days_col2 for an infrequent course component. 

So this PR...

- [X] creates `_data/quizzes.yml` following the structure of a weekly event
- [X] adds `quiz_days` and `starting_quiz_number` to `_data/syllabus.yml`
- [X] updates `_includes/schedule.html` to render quizzes.