### PR TITLE
Fix "Note" color in dark mode

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -29,6 +29,16 @@ div.highlighter-rouge div.highlight {
     border-collapse: collapse;
 }
 
+// fix Note block colors for dark mode
+p.note, blockquote.note {
+  border-left-color: #7253ed; 
+
+}
+p.note::before {
+  color: #7253ed;
+  font-weight: bold;
+}
+
 .label {
     border-radius: $border-radius;
     margin-left: 0;


### PR DESCRIPTION
Closes #61 

Before: 
<img width="1161" height="113" alt="Screenshot 2026-02-17 at 7 08 03 PM" src="https://github.com/user-attachments/assets/574b6a2f-e61b-4598-b62a-ac42b8c36082" />

After:
<img width="1165" height="103" alt="Screenshot 2026-02-17 at 7 08 24 PM" src="https://github.com/user-attachments/assets/477bb574-2f74-4769-934c-46f89bfa9485" />
